### PR TITLE
fix: StorePosterModal 컴포넌트에 props로 넘겨주던 userInfo가 필요 없어짐에 따라 삭제 #109

### DIFF
--- a/src/container/myPage/chatPage/components/HeaderBottom.tsx
+++ b/src/container/myPage/chatPage/components/HeaderBottom.tsx
@@ -85,9 +85,7 @@ const HeaderBottom = ({
         />
       )}
 
-      {onModalBg && (
-        <StorePosterModal storeId={roomInfoState.storeId} userInfo={userInfo} />
-      )}
+      {onModalBg && <StorePosterModal storeId={roomInfoState.storeId} />}
     </>
   );
 };


### PR DESCRIPTION
fix: StorePosterModal 컴포넌트에 props로 넘겨주던 userInfo가 필요 없어짐에 따라 삭제